### PR TITLE
Refactor config.py, add accounts variables

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,5 +2,8 @@ IPFS_API_SERVER_ADDRESS=/ip4/127.0.0.1/tcp/5001
 WEB3_PROVIDER_URI=https://mainnet.infura.io/v3/<infura-project-id>
 ETHERSCAN_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# Path to the keystore (defaults to ~/.paralink-node/ethkey.json)
+ETHEREUM_KEYSTORE_PATH='~/path/keystore.json'
+
 DATABASE_URL=postgres://user:pass@localhost/dbname
 CELERY_BROKER_URL="amqp://localhost"

--- a/Pipfile
+++ b/Pipfile
@@ -35,6 +35,7 @@ psycopg2 = "*"
 jedi = "==0.17.2"
 web3 = "==5.11.1"
 celery = "*"
+stdiomask = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d35b97719add1a7c118c97e45df6ea050fe8f9a8e55a3c4c4d0618969ac424ec"
+            "sha256": "2fda366a5648f7d9d9ae8c84fffe072589a72bb8cd0c8a0f81bb4b2aa16d9297"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1104,6 +1104,13 @@
             ],
             "index": "pypi",
             "version": "==1.3.22"
+        },
+        "stdiomask": {
+            "hashes": [
+                "sha256:c1e47069ead9e10bda150a26f7922ca01d2adc503042a9d7acf64877a2b9a3a6"
+            ],
+            "index": "pypi",
+            "version": "==0.0.6"
         },
         "toml": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -6,26 +6,33 @@ all supported chains via callbacks. Paralink Node is also a dependency to the on
 ## Configure
 Before running the node, please setup your `.env`. Copy the `.env.template` file to `.env` and modify the variables.
 
-Migrate the DB with:
+### Database
+
+A PostgreSQL DB is required for node to function. Migrate the DB with:
 
 ```
 pipenv run alembic upgrade head
 ```
 
-## Run
+### IPFS
 
-We suggest using Docker to run the image:
+For executing PQL definition an IPFS daemon is required. You can start it with:
 
 ```
-docker build -t paralink-node .
-docker run -it -p 7424:7424 paralink-node ./paralink-node node start --host 0.0.0.0
+IPFS_PATH=~/.ipfs ipfs daemon &
 ```
 
-Otherwise you can build the node yourself:
+### Ethereum chain
+
+For processing events on Ethereum, a node is required. It can be specified in `.env` file through `WEB3_PROVIDER_URI` variable. For Infura node provide the whole address.
+
+## Run step by step
+
+Running the node is a multistage process:
 
 ```
 pipenv sync
-./paralink-node
+./paralink-node node start
 ```
 
 The node will by default listen on port `7424`.
@@ -34,11 +41,50 @@ The node exposes two JSON RPC methods, which will execute PQL depending on the l
  - `execute_pql(pql_json)`: submit PQL JSON in the JSON RPC request (see [simple_get_request.py](examples/simple_get_request.py))
  - `execute_ipfs(ipfs_address, ipfs_hash)`: submit IPFS node address and IPFS hash where your PQL JSON is located (see [examples/ipfs_request.py](examples/ipfs_request.py))
 
-Furthermore see [examples](examples) folder for additional examples on how to use the node.
+Furthermore see [examples](examples) folder for additional examples on how to use the node directly.
+
+#### Event processing
+
+To start listening for on-chain events start celery workers:
+
+```
+docker run -d -p 5672:5672 rabbitmq
+pipenv run celery -A src.process.processor worker -l DEBUG -Q collect,execute
+```
+
+which spawns two queues for collecting events and executing PQL definitions defined in the events.
+
+Solidity contracts are available [here](https://github.com/paralink-network/solidity-contracts). Start a `ganache-cli` and call:
+
+```
+pipenv run brownie run oracle main
+```
+
+to deploy the `ParalinkOracle` contracts in the `solidity-contracts` repo.
+
+## Docker run
+
+We suggest using Docker to run the image:
+
+```
+docker build -t paralink-node .
+docker run -it -p 7424:7424 paralink-node ./paralink-node node start --host 0.0.0.0
+```
+
+`docker-compose.yml` file is also available.
+
 
 ## Web UI
 
 A Web UI is accessible on [localhost:7424](http://localhost:7424). It lists all your local IPFS files as well as allows you to create your own PQL definitions, test them and save them to IPFS.
+
+### Account management
+
+Private keys can be imported with the following command.
+
+```
+./paralink-node accounts import <private_key>
+```
 
 ## Docs
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -19,9 +19,9 @@ from src.process.collector import start_collecting
 from src.models import db
 
 
-def create_app(args={}, environment="development") -> Sanic:
+def create_app(args={}) -> Sanic:
     app = Sanic("src")
-    app.config.from_object(config[environment])
+    app.config.from_object(config)
 
     jsonrpc = SanicJsonrpc(app, post_route="/rpc", ws_route="/ws")
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,6 +1,10 @@
 from docopt import docopt
 from src.config import __version__
 
+import src.cli.node
+import src.cli.accounts
+from src.logging import setup_logging
+
 __doc__ = """
 Paralink Node is responsible for accessing real world data and relaying it back
 to smart contracts via JSON RPC.
@@ -22,10 +26,12 @@ see 'paralink-node <command> --help' for more information on a specific command.
 def main():
     args = docopt(__doc__, version=__version__, options_first=True)
 
-    if args["<command>"] == "node":
-        import src.cli.node
+    setup_logging()
 
+    if args["<command>"] == "node":
         src.cli.node.main()
+    elif args["<command>"] == "accounts":
+        src.cli.accounts.main()
 
 
 if __name__ == "__main__":

--- a/src/cli/accounts.py
+++ b/src/cli/accounts.py
@@ -1,0 +1,30 @@
+from docopt import docopt
+
+from src.network import accounts
+
+__doc__ = """
+Usage: paralink-node accounts <command> [<arguments> ...] [options]
+
+Commands:
+   import <private_key>     Import private key into paralink dir.
+
+Manage accounts.
+"""
+
+
+def main():
+    args = docopt(__doc__)
+
+    try:
+        if args["<command>"] == "import":
+            accounts.load()
+            accounts.import_key(*args["<arguments>"])
+    except TypeError:
+        print(
+            f"Invalid arguments for command '{args['<command>']}'. Try paralink-node accounts --help"
+        )
+        return
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cli/node.py
+++ b/src/cli/node.py
@@ -1,14 +1,14 @@
-import argparse
-import textwrap
 from docopt import docopt
 
 from src import create_app
+from src.config import config
+from src.network import accounts
 
 __doc__ = """
 Usage: paralink-node node <command> [<arguments> ...] [options]
 
 Commands:
-   start [--host]           Start the node.
+   start                    Start the node.
 
 Options:
    --host <host>            Specify host to run on [default: 127.0.0.1]
@@ -23,8 +23,10 @@ def main():
     args = docopt(__doc__)
 
     if args["<command>"] == "start":
+        accounts.load()
+
         app = create_app(args)
-        app.run(host=args["--host"], port=args["--port"], debug=True)
+        app.run(host=args["--host"], port=args["--port"], debug=config.DEBUG)
 
 
 if __name__ == "__main__":

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,10 @@
+import json
+import logging
 from os import getenv
-from dotenv import load_dotenv
+import sys
+from pathlib import Path
 
-from src.pql.handlers.rest_api_handler import RestApiHandler
+from dotenv import load_dotenv
 
 __version__ = "0.1.0"
 
@@ -10,8 +13,8 @@ load_dotenv(".env")
 
 
 class Config:
-    DEBUG = False
-    TESTING = False
+    DEBUG = getenv("DEBUG", "False") == "True"
+    TESTING = getenv("TESTING", "False") == "True"
 
     # Ethereum
     ETHERSCAN_KEY = getenv("ETHERSCAN_KEY")
@@ -25,216 +28,29 @@ class Config:
     # Default number of confirmations for ETH finality
     DEFAULT_NUM_CONFIRMATIONS = 40
 
-    TEMPLATE_PQL_DEFINITION = {
-        "name": "My job name",
-        "psql_version": "0.1",
-        "sources": [
-            {
-                "name": "Pipeline 1 name",
-                "pipeline": [
-                    {
-                        "step": "extract",
-                        "method": "http.get",
-                        "uri": "https://my-crypto-api.com/tickers",
-                    },
-                ],
-            },
-            {
-                "name": "Pipeline 2 name",
-                "pipeline": [
-                    {
-                        "step": "extract",
-                        "method": "http.get",
-                        "uri": "https://my-crypto-api.com/tickers",
-                    },
-                ],
-            },
-        ],
-        "aggregate": {"method": "mean"},
-        "callback": [
-            {
-                "type": "chain.eth",
-                "params": {
-                    "address": "<ORACLE ETH ADDRESS>",
-                    "function": "fulfillRequest",
-                    "args": [],
-                },
-            },
-            {
-                "type": "chain.plasm",
-                "params": {
-                    "address": "<ORACLE PLASM ADDRESS>",
-                    "function": "fulfillRequest",
-                    "args": [],
-                },
-            },
-        ],
-    }
+    # Node data folder
+    DATA_FOLDER = Path.home().joinpath(".paralink")
+    ETHEREUM_KEYSTORE_PATH = getenv(
+        "ETHEREUM_KEYSTORE_PATH", DATA_FOLDER.joinpath("ethkey.json")
+    )
+
+    # Use ETH keystore password directly from the env variable
+    USE_ENV_VARIABLE_FOR_ETHEREUM_KEYSTORE = (
+        getenv("USE_ENV_VARIABLE_FOR_ETHEREUM_KEYSTORE", "False") == "True"
+    )
+    # Only used if above is True
+    ETHEREUM_KEYSTORE_PASSWORD = getenv("ETHEREUM_KEYSTORE_PASSWORD", "paralink")
+
+    TEMPLATE_PQL_DEFINITION = json.load(open("src/data/oracle_abi.json"))
+    ORACLE_CONTRACT_ABI = json.load(open("src/data/oracle_abi.json"))
 
     # User defined custom functions
     PQL_CUSTOM_METHODS = {
         # "my_add": lambda step, index, pipeline: pipeline.get_value_for_step(index - 1) + step["params"]
     }
 
-    ORACLE_CONTRACT_ABI = [
-        {
-            "inputs": [],
-            "name": "constructor",
-            "stateMutability": "nonpayable",
-            "type": "constructor",
-        },
-        {
-            "anonymous": False,
-            "inputs": [
-                {
-                    "indexed": True,
-                    "internalType": "address",
-                    "name": "previousOwner",
-                    "type": "address",
-                },
-                {
-                    "indexed": True,
-                    "internalType": "address",
-                    "name": "newOwner",
-                    "type": "address",
-                },
-            ],
-            "name": "OwnershipTransferred",
-            "type": "event",
-        },
-        {
-            "anonymous": False,
-            "inputs": [
-                {
-                    "indexed": True,
-                    "internalType": "bytes32",
-                    "name": "ipfsHash",
-                    "type": "bytes32",
-                },
-                {
-                    "indexed": True,
-                    "internalType": "address",
-                    "name": "requester",
-                    "type": "address",
-                },
-                {
-                    "indexed": True,
-                    "internalType": "bytes32",
-                    "name": "requestId",
-                    "type": "bytes32",
-                },
-                {
-                    "indexed": False,
-                    "internalType": "address",
-                    "name": "callbackAddress",
-                    "type": "address",
-                },
-                {
-                    "indexed": False,
-                    "internalType": "bytes4",
-                    "name": "_callbackFunctionId",
-                    "type": "bytes4",
-                },
-                {
-                    "indexed": False,
-                    "internalType": "uint256",
-                    "name": "expiration",
-                    "type": "uint256",
-                },
-                {
-                    "indexed": False,
-                    "internalType": "bytes",
-                    "name": "data",
-                    "type": "bytes",
-                },
-            ],
-            "name": "Request",
-            "type": "event",
-        },
-        {
-            "inputs": [],
-            "name": "EXPIRY_TIME",
-            "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-            "stateMutability": "view",
-            "type": "function",
-        },
-        {
-            "inputs": [],
-            "name": "owner",
-            "outputs": [{"internalType": "address", "name": "", "type": "address"}],
-            "stateMutability": "view",
-            "type": "function",
-        },
-        {
-            "inputs": [],
-            "name": "renounceOwnership",
-            "outputs": [],
-            "stateMutability": "nonpayable",
-            "type": "function",
-        },
-        {
-            "inputs": [
-                {"internalType": "bytes32", "name": "_ipfsHash", "type": "bytes32"},
-                {"internalType": "address", "name": "_sender", "type": "address"},
-                {
-                    "internalType": "address",
-                    "name": "_callbackAddress",
-                    "type": "address",
-                },
-                {
-                    "internalType": "bytes4",
-                    "name": "_callbackFunctionId",
-                    "type": "bytes4",
-                },
-                {"internalType": "uint256", "name": "_nonce", "type": "uint256"},
-                {"internalType": "bytes", "name": "_data", "type": "bytes"},
-            ],
-            "name": "request",
-            "outputs": [],
-            "stateMutability": "nonpayable",
-            "type": "function",
-        },
-        {
-            "inputs": [
-                {"internalType": "address", "name": "_node", "type": "address"},
-                {"internalType": "bool", "name": "_allowed", "type": "bool"},
-            ],
-            "name": "setAuthorizedNode",
-            "outputs": [],
-            "stateMutability": "nonpayable",
-            "type": "function",
-        },
-        {
-            "inputs": [
-                {"internalType": "address", "name": "newOwner", "type": "address"}
-            ],
-            "name": "transferOwnership",
-            "outputs": [],
-            "stateMutability": "nonpayable",
-            "type": "function",
-        },
-    ]
-
-    @staticmethod
-    def init_app(app):
-        pass
+    def __init__(self):
+        Path(self.DATA_FOLDER).mkdir(exist_ok=True)
 
 
-class DevelopmentConfig(Config):
-    DEBUG = True
-
-
-class ProductionConfig(Config):
-    pass
-
-
-class TestingConfig(Config):
-    TESTING = True
-
-
-config = {
-    "development": DevelopmentConfig,
-    "testing": TestingConfig,
-    "production": ProductionConfig,
-    "default": DevelopmentConfig,
-}
+config = Config()

--- a/src/data/default_pql_template_definition.json
+++ b/src/data/default_pql_template_definition.json
@@ -1,0 +1,45 @@
+{
+        "name": "My job name",
+        "psql_version": "0.1",
+        "sources": [
+            {
+                "name": "Pipeline 1 name",
+                "pipeline": [
+                    {
+                        "step": "extract",
+                        "method": "http.get",
+                        "uri": "https://my-crypto-api.com/tickers"
+                    }
+                ]
+            },
+            {
+                "name": "Pipeline 2 name",
+                "pipeline": [
+                    {
+                        "step": "extract",
+                        "method": "http.get",
+                        "uri": "https://my-crypto-api.com/tickers"
+                    }
+                ]
+            }
+        ],
+        "aggregate": {"method": "mean"},
+        "callback": [
+            {
+                "type": "chain.eth",
+                "params": {
+                    "address": "<ORACLE ETH ADDRESS>",
+                    "function": "fulfillRequest",
+                    "args": []
+                }
+            },
+            {
+                "type": "chain.plasm",
+                "params": {
+                    "address": "<ORACLE PLASM ADDRESS>",
+                    "function": "fulfillRequest",
+                    "args": []
+                }
+            }
+        ]
+}

--- a/src/data/oracle_abi.json
+++ b/src/data/oracle_abi.json
@@ -1,0 +1,138 @@
+[
+        {
+            "inputs": [],
+            "name": "constructor",
+            "stateMutability": "nonpayable",
+            "type": "constructor"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "ipfsHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "requester",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "requestId",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "callbackAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes4",
+                    "name": "_callbackFunctionId",
+                    "type": "bytes4"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "expiration",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Request",
+            "type": "event"
+        },
+        {
+            "inputs": [],
+            "name": "EXPIRY_TIME",
+            "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "owner",
+            "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "renounceOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {"internalType": "bytes32", "name": "_ipfsHash", "type": "bytes32"},
+                {"internalType": "address", "name": "_sender", "type": "address"},
+                {
+                    "internalType": "address",
+                    "name": "_callbackAddress",
+                    "type": "address"
+                },
+                {
+                    "internalType": "bytes4",
+                    "name": "_callbackFunctionId",
+                    "type": "bytes4"
+                },
+                {"internalType": "uint256", "name": "_nonce", "type": "uint256"},
+                {"internalType": "bytes", "name": "_data", "type": "bytes"}
+            ],
+            "name": "request",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {"internalType": "address", "name": "_node", "type": "address"},
+                {"internalType": "bool", "name": "_allowed", "type": "bool"}
+            ],
+            "name": "setAuthorizedNode",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {"internalType": "address", "name": "newOwner", "type": "address"}
+            ],
+            "name": "transferOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        }
+]

--- a/src/data/oracle_abi.json
+++ b/src/data/oracle_abi.json
@@ -1,138 +1,183 @@
 [
-        {
-            "inputs": [],
-            "name": "constructor",
-            "stateMutability": "nonpayable",
-            "type": "constructor"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "previousOwner",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "newOwner",
-                    "type": "address"
-                }
-            ],
-            "name": "OwnershipTransferred",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "bytes32",
-                    "name": "ipfsHash",
-                    "type": "bytes32"
-                },
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "requester",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "internalType": "bytes32",
-                    "name": "requestId",
-                    "type": "bytes32"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "address",
-                    "name": "callbackAddress",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "bytes4",
-                    "name": "_callbackFunctionId",
-                    "type": "bytes4"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "expiration",
-                    "type": "uint256"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "bytes",
-                    "name": "data",
-                    "type": "bytes"
-                }
-            ],
-            "name": "Request",
-            "type": "event"
-        },
-        {
-            "inputs": [],
-            "name": "EXPIRY_TIME",
-            "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "owner",
-            "outputs": [{"internalType": "address", "name": "", "type": "address"}],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "renounceOwnership",
-            "outputs": [],
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {"internalType": "bytes32", "name": "_ipfsHash", "type": "bytes32"},
-                {"internalType": "address", "name": "_sender", "type": "address"},
-                {
-                    "internalType": "address",
-                    "name": "_callbackAddress",
-                    "type": "address"
-                },
-                {
-                    "internalType": "bytes4",
-                    "name": "_callbackFunctionId",
-                    "type": "bytes4"
-                },
-                {"internalType": "uint256", "name": "_nonce", "type": "uint256"},
-                {"internalType": "bytes", "name": "_data", "type": "bytes"}
-            ],
-            "name": "request",
-            "outputs": [],
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {"internalType": "address", "name": "_node", "type": "address"},
-                {"internalType": "bool", "name": "_allowed", "type": "bool"}
-            ],
-            "name": "setAuthorizedNode",
-            "outputs": [],
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {"internalType": "address", "name": "newOwner", "type": "address"}
-            ],
-            "name": "transferOwnership",
-            "outputs": [],
-            "stateMutability": "nonpayable",
-            "type": "function"
-        }
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor",
+    "name": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "ipfsHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "requester",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "requestId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "callbackAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes4",
+        "name": "callbackFunctionId",
+        "type": "bytes4"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expiration",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "Request",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "requestId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RequestCanceled",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "EXPIRY_TIME",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "_requestId", "type": "bytes32" },
+      { "internalType": "bytes4", "name": "_callbackFunc", "type": "bytes4" },
+      { "internalType": "uint256", "name": "_expiration", "type": "uint256" }
+    ],
+    "name": "cancelRequest",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "_requestId", "type": "bytes32" },
+      {
+        "internalType": "address",
+        "name": "_callbackAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes4",
+        "name": "_callbackFunctionId",
+        "type": "bytes4"
+      },
+      { "internalType": "uint256", "name": "_expiration", "type": "uint256" },
+      { "internalType": "bytes32", "name": "_data", "type": "bytes32" }
+    ],
+    "name": "fulfillRequest",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "_ipfsHash", "type": "bytes32" },
+      { "internalType": "address", "name": "_sender", "type": "address" },
+      {
+        "internalType": "address",
+        "name": "_callbackAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes4",
+        "name": "_callbackFunctionId",
+        "type": "bytes4"
+      },
+      { "internalType": "uint256", "name": "_nonce", "type": "uint256" },
+      { "internalType": "bytes", "name": "_data", "type": "bytes" }
+    ],
+    "name": "request",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_node", "type": "address" },
+      { "internalType": "bool", "name": "_allowed", "type": "bool" }
+    ],
+    "name": "setAuthorizedNode",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
 ]

--- a/src/logging.py
+++ b/src/logging.py
@@ -1,0 +1,17 @@
+import logging
+import sys
+from src.config import config
+
+
+def setup_logging():
+    logging_format = (
+        "%(asctime)s [%(process)d] [%(levelname)s] "
+        "%(module)s::%(funcName)s():l%(lineno)d: "
+        "%(message)s"
+    )
+    logging.basicConfig(
+        stream=sys.stdout,
+        level=logging.DEBUG if config.DEBUG else logging.INFO,
+        format=logging_format,
+    )
+    logging.getLogger("sanic.root").propagate = False

--- a/src/network/__init__.py
+++ b/src/network/__init__.py
@@ -1,0 +1,3 @@
+from src.network.accounts import Accounts
+
+accounts = Accounts()

--- a/src/network/accounts.py
+++ b/src/network/accounts.py
@@ -1,0 +1,77 @@
+# from getpass import getpass
+import stdiomask
+import json
+import logging
+from pathlib import Path
+
+from src.config import config
+from src.network.web3 import w3
+
+logger = logging.getLogger(__name__)
+
+
+class Accounts:
+    """Accounts manages node accounts on different chains.
+    """
+
+    def __init__(self):
+        self.ethkey = None
+
+    def load(self):
+        """Load private keys from the env variables. Creates a new account if private key
+        does not exist.
+        """
+        eth_json = Path(config.ETHEREUM_KEYSTORE_PATH)
+        logger.info(f"Loading ETH private key from {eth_json}")
+
+        if eth_json.exists():
+            password = self.get_password(f"Enter the password for {eth_json} ")
+            with eth_json.open() as fp:
+                private_key = w3.eth.account.decrypt(json.load(fp), password)
+                self.ethkey = w3.eth.account.from_key(private_key)
+        else:
+            logger.info(f"Private key not found. A new one will be created.")
+            self.ethkey = w3.eth.account.create()
+            self.save(self.ethkey)
+
+        logger.info(f"Using ETH address: {self.ethkey.address}")
+
+    def save(self, ethkey):
+        """Save given LocalACcount to ETH keystore.
+
+        Args:
+            ethkey: eth_account.LocalAccount
+        """
+        eth_json = Path(config.ETHEREUM_KEYSTORE_PATH)
+
+        password = self.get_password(
+            f"Enter the password to encrypt new ETH private key {eth_json}: ",
+        )
+        encrypted = w3.eth.account.encrypt(ethkey.privateKey, password)
+
+        # Write back the newly generate private key
+        with eth_json.open("w") as fp:
+            json.dump(encrypted, fp)
+            logger.info(f"{eth_json} was created and encrypted.")
+
+    def import_key(self, private_key: str):
+        """Imports given private_key into ETH keystore.
+
+        Args:
+            private_key: private key to be imported.
+        """
+        self.ethkey = w3.eth.account.from_key(private_key)
+        self.save(self.ethkey)
+
+        logger.info(f"Successfully imported key {self.ethkey.address}")
+
+    def get_password(self, message) -> str:
+        """Prompts user for password (hidden input).
+
+        Args:
+            message: Message to be displayed before prompt.
+        """
+        if config.USE_ENV_VARIABLE_FOR_ETHEREUM_KEYSTORE:
+            return config.ETHEREUM_KEYSTORE_PASSWORD
+        else:
+            return stdiomask.getpass(message)

--- a/src/network/web3.py
+++ b/src/network/web3.py
@@ -1,0 +1,6 @@
+from dotenv import load_dotenv
+from web3 import Web3
+
+load_dotenv(".env")
+
+w3 = Web3()

--- a/src/pql/handlers/eth_handler.py
+++ b/src/pql/handlers/eth_handler.py
@@ -7,8 +7,8 @@ import asyncpg
 from sanic.log import logger
 
 
-from src.config import Config
-from src.utils import w3
+from src.config import config
+from src.network.web3 import w3
 from src.pql.handlers.handler import Handler
 from src.pql.exceptions import MethodNotFound, ExternalError, ArgumentError
 
@@ -35,7 +35,7 @@ class EthHandler(Handler):
 
                 params = step["params"]
                 num_confirmations = (
-                    Config().DEFAULT_NUM_CONFIRMATIONS
+                    config.DEFAULT_NUM_CONFIRMATIONS
                     if "num_confirmations" not in params
                     else params["num_confirmations"]
                 )
@@ -62,7 +62,7 @@ class EthHandler(Handler):
             params = step["params"]
             args = params["args"]
             num_confirmations = (
-                Config().DEFAULT_NUM_CONFIRMATIONS
+                config.DEFAULT_NUM_CONFIRMATIONS
                 if "num_confirmations" not in params
                 else params["num_confirmations"]
             )
@@ -108,7 +108,7 @@ class EthHandler(Handler):
             "module": "contract",
             "action": action,
             "address": address,
-            "apiKey": Config().ETHERSCAN_KEY,
+            "apiKey": config.ETHERSCAN_KEY,
         }
 
         # Check for existence of ETHERSCAN_KEY

--- a/src/pql/pipeline.py
+++ b/src/pql/pipeline.py
@@ -5,7 +5,7 @@ from src.pql.exceptions import StepNotFound, MethodNotFound, NoInputValue
 from src.pql.handlers.rest_api_handler import RestApiHandler
 from src.pql.handlers.sql_handler import SqlHandler
 from src.pql.handlers.eth_handler import EthHandler
-from src.config import Config
+from src.config import config
 
 
 class Pipeline:
@@ -20,7 +20,6 @@ class Pipeline:
         """
         self.pipeline = pipeline
         self.step_results = []
-        self.config = Config()
 
     async def execute(self) -> None:
         """Execute `self.pipeline` step by step.
@@ -42,8 +41,8 @@ class Pipeline:
             elif step["step"].startswith("custom"):
                 custom_step = step["step"].split(".")[-1]
 
-                if custom_step in self.config.PQL_CUSTOM_METHODS:
-                    result = self.config.PQL_CUSTOM_METHODS[custom_step](step, i, self)
+                if custom_step in config.PQL_CUSTOM_METHODS:
+                    result = config.PQL_CUSTOM_METHODS[custom_step](step, i, self)
 
                 else:
                     raise StepNotFound(f"custom step \"{step['step']}\" not found")

--- a/src/process/__init__.py
+++ b/src/process/__init__.py
@@ -1,10 +1,10 @@
 from celery import Celery
 
-from src.config import Config
+from src.config import config
 
 processor = Celery(
     "job-processor",
-    broker=Config().CELERY_BROKER_URL,
+    broker=config.CELERY_BROKER_URL,
     include=["src.process.collector", "src.process.executor"],
 )
 

--- a/src/process/__init__.py
+++ b/src/process/__init__.py
@@ -1,6 +1,9 @@
 from celery import Celery
 
 from src.config import config
+from src.network import accounts
+
+accounts.load()
 
 processor = Celery(
     "job-processor",

--- a/src/process/collector.py
+++ b/src/process/collector.py
@@ -8,6 +8,8 @@ from src.process.executor import handle_request_event
 
 
 async def start_collecting():
+    """Initiates collecting tasks for addresses specified in the PostgreSQL DB.
+    """
     for contract_oracle in await ContractOracle.query.gino.all():
         listen_for_request_events.delay(contract_oracle.id, 2)
 

--- a/src/process/collector.py
+++ b/src/process/collector.py
@@ -1,8 +1,8 @@
 import time
 
-from src.config import Config
+from src.config import config
 from src.models import db, ContractOracle
-from src.utils import w3
+from src.network.web3 import w3
 from src.process import processor
 from src.process.executor import handle_request_event
 
@@ -21,7 +21,7 @@ def listen_for_request_events(address: str, poll_interval: int) -> None:
         address: contract oracle address.
         poll_interval: time between the checks.
     """
-    contract = w3.eth.contract(abi=Config.ORACLE_CONTRACT_ABI, address=address)
+    contract = w3.eth.contract(abi=config.ORACLE_CONTRACT_ABI, address=address)
     event_filter = contract.events.Request.createFilter(fromBlock="latest")
 
     while True:

--- a/src/process/executor.py
+++ b/src/process/executor.py
@@ -5,8 +5,8 @@ from celery.utils.log import get_task_logger
 import ipfshttpclient
 
 from . import processor
-from src.config import Config
-from src.utils import w3
+from src.config import config
+from src.network.web3 import w3
 
 from src.pql.parser import parse_and_execute
 from src.utils.ipfs import bytes32_to_ipfs
@@ -29,7 +29,7 @@ def handle_request_event(self, event) -> None:
     expiration = datetime.fromtimestamp(args["expiration"])
 
     try:
-        ipfs = ipfshttpclient.connect(Config.IPFS_API_SERVER_ADDRESS)
+        ipfs = ipfshttpclient.connect(config.IPFS_API_SERVER_ADDRESS)
         req = ipfs.get_json(ipfs_hash, timeout=3)
 
         logger.debug(f"Obtained PQL definition {req}")

--- a/src/process/executor.py
+++ b/src/process/executor.py
@@ -10,6 +10,7 @@ from src.network.web3 import w3
 
 from src.pql.parser import parse_and_execute
 from src.utils.ipfs import bytes32_to_ipfs
+from src.network import accounts
 
 logger = get_task_logger(__name__)
 
@@ -22,7 +23,6 @@ def handle_request_event(self, event) -> None:
     Args:
         event: Solidity Request event
     """
-    print(event)
     args = event["args"]
 
     ipfs_hash = bytes32_to_ipfs(args["ipfsHash"])
@@ -37,8 +37,7 @@ def handle_request_event(self, event) -> None:
         res = asyncio.run(parse_and_execute(req))
         logger.info(f"Obtained result {res}")
 
-        # TODO: use callback
-        print(f"Writing {res} to callback")
+        write_to_eth_chain(event, res)
     except Exception as e:
         if datetime.now() < expiration:
             self.retry(exc=e)
@@ -47,3 +46,32 @@ def handle_request_event(self, event) -> None:
                 f"Request {args['requestId']} from {args['requester']} expired due to {str(type(e))}: {e.args[0]}"
             )
             return
+
+
+def write_to_eth_chain(event, res):
+    """It writes `res` (result of the PQL definition) to the location specified in the `Request` event.
+
+    Args:
+        event: a Request event from ETH chain.
+        res: already executed PQL definition
+    """
+    logger.info(f"Writing {res} to ETH chain")
+
+    args = event["args"]
+    contract = w3.eth.contract(abi=config.ORACLE_CONTRACT_ABI, address=event["address"])
+
+    tx = contract.functions.fulfillRequest(
+        args["requestId"],
+        args["callbackAddress"],
+        args["callbackFunctionId"],
+        args["expiration"],
+        w3.toBytes(int(res)).rjust(32, b"\0"),
+    ).buildTransaction()
+
+    tx.update({"nonce": w3.eth.getTransactionCount(accounts.ethkey.address)})
+
+    signed_tx = w3.eth.account.signTransaction(tx, accounts.ethkey.privateKey)
+    tx_hash = w3.eth.sendRawTransaction(signed_tx.rawTransaction)
+    tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+
+    logger.info(tx_receipt)

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,8 +1,1 @@
-from dotenv import load_dotenv
-
-from web3 import Web3
-
-load_dotenv(".env")
-
-w3 = Web3()
 

--- a/tests/integration/test_custom_function.py
+++ b/tests/integration/test_custom_function.py
@@ -64,15 +64,16 @@ async def test_custom_function(client, mocker, pql):
             payload={"bitcoin": {"usd": 25000}},
         )
 
-        obj = MagicMock()
-        obj.PQL_CUSTOM_METHODS = {
+        PQL_CUSTOM_METHODS = {
             "my_add": lambda step, index, pipeline: pipeline.get_value_for_step(
                 index - 1
             )
             + step["params"]
         }
 
-        mocker.patch("src.pql.pipeline.Config", return_value=obj)
+        mocker.patch.dict(
+            "src.pql.pipeline.config.PQL_CUSTOM_METHODS", PQL_CUSTOM_METHODS
+        )
 
         request = {
             "jsonrpc": "2.0",


### PR DESCRIPTION
- adds data folder `.paralink`
- adds keystore management, a key can be imported with `./paralink-node accounts import` function otherwise if empty it is created on start
- refactors config
- `execute` queue now also writes back to the chain depending on the `Request` event data