### PR TITLE
Add documentation regarding the background worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ docker run --detach --rm -p 9933:9933 -p 9944:9944 -p 9615:9615 \
 
 ## Run step by step
 
+To run a celery background worker to collect and process on-chain events, an instance of rabbitmq is required:
+
+```
+docker run -d -p 5672:5672 rabbitmq
+```
+
+Alternatively you can disable the background worker by setting the following environment variable to false in the .env file:
+
+```
+ENABLE_BACKGROUND_WORKER="False"
+```
+
 Running the node is a multistage process:
 
 ```

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker run --detach --rm -p 9933:9933 -p 9944:9944 -p 9615:9615 \
 
 ## Run step by step
 
-To run a celery background worker to collect and process on-chain events, an instance of rabbitmq is required:
+To run a background worker to collect on-chain events, an instance of rabbitmq is required:
 
 ```
 docker run -d -p 5672:5672 rabbitmq

--- a/README.md
+++ b/README.md
@@ -77,11 +77,7 @@ docker run --detach --rm -p 9933:9933 -p 9944:9944 -p 9615:9615 \
 
 ## Run step by step
 
-To run a background worker to collect on-chain events, an instance of rabbitmq is required:
-
-```
-docker run -d -p 5672:5672 rabbitmq
-```
+If you want to run a background worker to collect on-chain events, see [Event processing](#event-processing).
 
 Alternatively you can disable the background worker by setting the following environment variable to false in the .env file:
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ docker run --detach --rm -p 9933:9933 -p 9944:9944 -p 9615:9615 \
 
 If you want to run a background worker to collect on-chain events, see [Event processing](#event-processing).
 
-Alternatively you can disable the background worker by setting the following environment variable to false in the .env file:
+Alternatively you can disable the background worker by setting the following environment variable to false in the [.env](.env.template) file:
 
 ```
 ENABLE_BACKGROUND_WORKER="False"


### PR DESCRIPTION
To run the node, an instance of rabbitmq (or reddis) must be available to act as a broker for the celery tasks.  Alternatively the background worker can be disabled as stated. 